### PR TITLE
Add *.tsx files and types instead of *.js

### DIFF
--- a/libs/client.ts
+++ b/libs/client.ts
@@ -2,5 +2,5 @@ import { createClient } from 'microcms-js-sdk';
 
 export const client = createClient({
   serviceDomain: 'yokoto',
-  apiKey: process.env.API_KEY,
+  apiKey: process.env.API_KEY!,
 });

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,7 +1,11 @@
-export default function Custom404() {
+import { NextPage } from 'next'
+
+const Custom404: NextPage= () => {
   return (
     <main className="main">
       <p>ページがありません。</p>
     </main>
   );
 }
+
+export default Custom404;

--- a/pages/blog/[id].tsx
+++ b/pages/blog/[id].tsx
@@ -1,7 +1,18 @@
+import type { NextPage, GetStaticProps, GetStaticPropsContext } from 'next'
+import  { Blog } from '../../types/blog';
+import  { Category } from '../../types/category';
+import  { Content } from '../../types/content';
+
 import { client } from '../../libs/client';
 import styles from '../../styles/Home.module.scss';
 
-export default function BlogId({ blog }) {
+type Props = {
+  blog: Blog
+}
+
+const BlogId: NextPage<Props> = (props: Props) => {
+  const { blog } = props;
+
   return (
     <main className={styles.main}>
       <h1 className={styles.title}>{blog.title}</h1>
@@ -23,14 +34,16 @@ export default function BlogId({ blog }) {
 export const getStaticPaths = async () => {
   const data = await client.get({ endpoint: "blog" });
 
-  const paths = data.contents.map((content) => `/blog/${content.id}`);
+  const paths = data.contents.map((content: Content) => `/blog/${content.id}`);
   return { paths, fallback: false };
 };
 
 // データをテンプレートに受け渡す部分の処理を記述します
-export const getStaticProps = async (context) => {
-  const id = context.params.id;
-  const data = await client.get({ endpoint: "blog", contentId: id });
+export const getStaticProps: GetStaticProps<Props> = async (
+  context: GetStaticPropsContext<{ id?: string }>
+) => {
+  const params = context.params!
+  const data = await client.get({ endpoint: "blog", contentId: params.id });
 
   return {
     props: {
@@ -38,3 +51,5 @@ export const getStaticProps = async (context) => {
     },
   };
 };
+
+export default BlogId

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,20 @@
+import type { NextPage, GetStaticProps, GetStaticPropsContext } from 'next'
+import type { Blog } from '../types/blog';
+
 import Link from "next/link";
 import { client } from "../libs/client";
 
-export default function Home({ blog }) {
+type Props = {
+  blogs: [Blog]
+}
+
+const Home: NextPage<Props> = (props: Props) => {
+  const { blogs } = props;
+
   return (
     <div>
       <ul>
-        {blog.map((blog) => (
+        {blogs.map((blog: Blog) => (
           <li key={blog.id}>
             <Link href={`/blog/${blog.id}`}>
               <a>{blog.title}</a>
@@ -21,12 +30,14 @@ export default function Home({ blog }) {
 // これは、ビルド時にサーバー側で呼ばれる関数です
 // この部分の処理は最終的にバンドルJSに含まれません
 // ビルド時にデータを取得し、静的なHTMLを出力するために必要です
-export const getStaticProps = async () => {
+export const getStaticProps: GetStaticProps<Props> = async () => {
   const data = await client.get({ endpoint: "blog" });
 
   return {
     props: {
-      blog: data.contents,
+      blogs: data.contents,
     },
   };
 };
+
+export default Home;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,14 +6,15 @@
       "dom.iterable",
       "esnext"
     ],
-    "allowJs": true,
+    "allowJs": false,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "incremental": true,
     "esModuleInterop": true,
     "module": "esnext",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve"

--- a/types/blog.ts
+++ b/types/blog.ts
@@ -1,0 +1,9 @@
+import { Category } from './category'
+
+export interface Blog {
+  id: string;
+  title: string;
+  publishedAt: string;
+  category: Category;
+  body: string;
+}

--- a/types/category.ts
+++ b/types/category.ts
@@ -1,0 +1,8 @@
+export interface Category {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  revisedAt: string;
+  name: string;
+}

--- a/types/content.ts
+++ b/types/content.ts
@@ -1,0 +1,12 @@
+import { Category } from './category'
+
+export interface Content {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string;
+  revisedAt: string;
+  title: string;
+  body: string;
+  category: Category;
+}


### PR DESCRIPTION
# Issue
#1 

# What I did

https://github.com/yokoto/microcms-next-jamstack-blog/pull/4 でTypeScript導入を行なったが、コード（pages\/\*や libs\/\*）でinterfacesを使ったり等の改善をした。

これで https://blog.microcms.io/microcms-next-jamstack-blog/ の記事のTypeScript版になったと思う 👍 

## 参考

https://maku.blog/p/ny9fmty/

https://zenn.dev/poyomitech/articles/d6b8ffb42e3cd4

https://dev.classmethod.jp/articles/vercel-microcms-nextjs-blog-sdk/
https://github.com/hbsnow-sandbox/nextjs-micro-cms-sdk-example

https://zenn.dev/yukionishi/articles/4c02ece789c34daadda5
https://github.com/YukiOnishi1129/nochitoku-blog